### PR TITLE
determine sdk path even if symlink is relative (e.g. when using brew)

### DIFF
--- a/lib/pebble_x/cli.rb
+++ b/lib/pebble_x/cli.rb
@@ -62,6 +62,7 @@ module PebbleX
           pebble_cmd = sys_call('which pebble').strip
           if pebble_cmd != ''
             real_path = sys_call("readlink #{pebble_cmd}")
+            real_path = File.expand_path("../#{real_path}", pebble_cmd) if real_path.start_with?('..')
             pebble_cmd = real_path if real_path != ''
 
             sdk_dir = File.expand_path('../..', pebble_cmd)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -99,6 +99,13 @@ describe 'CLI' do
       expect(c.pebble_sdk_dir).to eq '/path/to/sdk'
     end
 
+    it 'follows relative symlinks to determine sdk path' do
+      c = PebbleX::CLI.new
+      expect(c).to receive(:sys_call).with('which pebble').and_return '/some/relative/symlink'
+      expect(c).to receive(:sys_call).with('readlink /some/relative/symlink').and_return '../path/to/sdk/bin/pebble'
+      expect(c.pebble_sdk_dir).to eq '/some/path/to/sdk'
+    end
+
 
     it 'uses option pebble_sdk if provided' do
       c = PebbleX::CLI.new


### PR DESCRIPTION
I've installed Pebble SDK using brew.
`which pebble` returns `/usr/local/bin/pebble`.
`readlink /usr/local/bin/pebble` returns `../Cellar/pebble-sdk/3.4/bin/pebble` and the relative path is compared to current working directory instead of the symlink. Which is wrong.
This PR should fix it.
